### PR TITLE
Add NewKeySet method to JWTAuth

### DIFF
--- a/jwtauth_test.go
+++ b/jwtauth_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lestrrat-go/jwx/v2/jws"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/jwtauth/v5"
 	"github.com/lestrrat-go/jwx/v2/jwa"
@@ -41,6 +43,27 @@ MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBALxo3PCjFw4QjgOX06QCJIJBnXXNiEYw
 DLxxa5/7QyH6y77nCRQyJ3x3UwF9rUD0RCsp4sNdX5kOQ9PUyHyOtCUCAwEAAQ==
 -----END PUBLIC KEY-----
 `
+
+	KeySet = `{
+    "keys": [
+		{
+			"kty": "RSA",
+			"n": "vGjc8KMXDhCOA5fTpAIkgkGddc2IRjAMvHFrn_tDIfrLvucJFDInfHdTAX2tQPREKyniw11fmQ5D09TIfI60JQ",
+			"e": "AQAB",
+            "alg": "RS256",
+            "kid": "1",
+            "use": "sig"
+        },
+		{
+			"kty": "RSA",
+			"n": "foo",
+			"e": "AQAB",
+            "alg": "RS256",
+            "kid": "2",
+            "use": "sig"
+        }
+    ]
+}`
 )
 
 func init() {
@@ -50,6 +73,59 @@ func init() {
 //
 // Tests
 //
+
+func TestNewKeySet(t *testing.T) {
+	_, err := jwtauth.NewKeySet([]byte("not a valid key set"))
+	if err == nil {
+		t.Fatal("The error should not be nil")
+	}
+
+	_, err = jwtauth.NewKeySet([]byte(KeySet))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+}
+
+func TestKeySetRSA(t *testing.T) {
+	privateKeyBlock, _ := pem.Decode([]byte(PrivateKeyRS256String))
+
+	privateKey, err := x509.ParsePKCS1PrivateKey(privateKeyBlock.Bytes)
+
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	KeySetAuth, _ := jwtauth.NewKeySet([]byte(KeySet))
+	claims := map[string]interface{}{
+		"key":  "val",
+		"key2": "val2",
+		"key3": "val3",
+	}
+
+	signed := newJwtRSAToken(jwa.RS256, privateKey, "1", claims)
+
+	token, err := KeySetAuth.Decode(signed)
+
+	if err != nil {
+		t.Fatalf("Failed to decode token string %s\n", err.Error())
+	}
+
+	tokenClaims, err := token.AsMap(context.Background())
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if !reflect.DeepEqual(claims, tokenClaims) {
+		t.Fatalf("The decoded claims don't match the original ones\n")
+	}
+
+	_, _, err = KeySetAuth.Encode(claims)
+	if err.Error() != "no signing key provided" {
+		t.Fatalf("Expect error to equal %s. Found: %s.", "no signing key provided", err.Error())
+	}
+	fmt.Println(token.PrivateClaims())
+
+}
 
 func TestSimple(t *testing.T) {
 	r := chi.NewRouter()
@@ -279,20 +355,118 @@ func TestMore(t *testing.T) {
 	}
 }
 
-func TestEncodeClaims(t *testing.T) {
-	claims := map[string]interface{}{
-		"key1": "val1",
-		"key2": 2,
-		"key3": time.Now(),
-		"key4": []string{"1", "2"},
+func TestKeySet(t *testing.T) {
+	privateKeyBlock, _ := pem.Decode([]byte(PrivateKeyRS256String))
+	privateKey, err := x509.ParsePKCS1PrivateKey(privateKeyBlock.Bytes)
+	if err != nil {
+		t.Fatalf(err.Error())
 	}
-	claims[jwt.JwtIDKey] = 1
-	if _, _, err := TokenAuthHS256.Encode(claims); err == nil {
+
+	r := chi.NewRouter()
+
+	keySet, err := jwtauth.NewKeySet([]byte(KeySet))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// Protected routes
+	r.Group(func(r chi.Router) {
+		r.Use(jwtauth.Verifier(keySet))
+
+		authenticator := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				token, _, err := jwtauth.FromContext(r.Context())
+
+				if err != nil {
+					http.Error(w, jwtauth.ErrorReason(err).Error(), http.StatusUnauthorized)
+					return
+				}
+
+				if err := jwt.Validate(token); err != nil {
+					http.Error(w, jwtauth.ErrorReason(err).Error(), http.StatusUnauthorized)
+					return
+				}
+
+				// Token is authenticated, pass it through
+				next.ServeHTTP(w, r)
+			})
+		}
+		r.Use(authenticator)
+
+		r.Get("/admin", func(w http.ResponseWriter, r *http.Request) {
+			_, claims, err := jwtauth.FromContext(r.Context())
+
+			if err != nil {
+				w.Write([]byte(fmt.Sprintf("error! %v", err)))
+				return
+			}
+
+			w.Write([]byte(fmt.Sprintf("protected, user:%v", claims["user_id"])))
+		})
+	})
+
+	// Public routes
+	r.Group(func(r chi.Router) {
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("welcome"))
+		})
+	})
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	h := http.Header{}
+	h.Set("Authorization", "BEARER "+newJwtRSAToken(jwa.RS256, privateKey, "1", map[string]interface{}{"user_id": 31337, "exp": jwtauth.ExpireIn(5 * time.Minute)}))
+	if status, resp := testRequest(t, ts, "GET", "/admin", h, nil); status != 200 || resp != "protected, user:31337" {
+		t.Fatalf(resp)
+	}
+}
+
+func TestEncodeInvalidClaim(t *testing.T) {
+	ja := jwtauth.New("HS256", []byte("secretpass"), nil)
+	claims := map[string]interface{}{
+		"key1":       "val1",
+		"key2":       2,
+		"key3":       time.Now(),
+		"key4":       []string{"1", "2"},
+		jwt.JwtIDKey: 1, // This is invalid becasue it should be a string
+	}
+	_, _, err := ja.Encode(claims)
+	if err == nil {
+
 		t.Fatal("encoding invalid claims succeeded")
 	}
-	claims[jwt.JwtIDKey] = "123"
-	if _, _, err := TokenAuthHS256.Encode(claims); err != nil {
-		t.Fatalf("unexpected error encoding valid claims: %v", err)
+}
+func TestEncode(t *testing.T) {
+	ja := jwtauth.New("HS256", []byte("secretpass"), nil)
+
+	claims := map[string]interface{}{
+		"sub":  "1234567890",
+		"name": "John Doe",
+		"iat":  1516239022,
+	}
+
+	token, tokenString, err := ja.Encode(claims)
+	if err != nil {
+		t.Fatalf("Failed to encode claims: %s", err.Error())
+	}
+
+	if token == nil {
+		t.Fatal("Token should not be nil")
+	}
+
+	if tokenString == "" {
+		t.Fatal("Token string should not be empty")
+	}
+
+	// Verify the token string
+	verifiedToken, err := ja.Decode(tokenString)
+	if err != nil {
+		t.Fatalf("Failed to decode token string: %s", err.Error())
+	}
+
+	if !reflect.DeepEqual(token, verifiedToken) {
+		t.Fatal("Decoded token does not match the original token")
 	}
 }
 
@@ -351,6 +525,29 @@ func newJwt512Token(secret []byte, claims ...map[string]interface{}) string {
 		}
 	}
 	tokenPayload, err := jwt.Sign(token, jwt.WithKey(jwa.HS512, secret))
+	if err != nil {
+		log.Fatal(err)
+	}
+	return string(tokenPayload)
+}
+
+func newJwtRSAToken(alg jwa.SignatureAlgorithm, secret interface{}, kid string, claims ...map[string]interface{}) string {
+	token := jwt.New()
+	if len(claims) > 0 {
+		for k, v := range claims[0] {
+			token.Set(k, v)
+		}
+	}
+
+	headers := jws.NewHeaders()
+	if kid != "" {
+		err := headers.Set("kid", kid)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	tokenPayload, err := jwt.Sign(token, jwt.WithKey(alg, secret, jws.WithProtectedHeaders(headers)))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This commit adds support for KeySets through a new method `NewKeySet` to the `JWTAuth` struct.

It includes tests and comments that seek to explain how it works inline.

There's also an example in the _example directory that shows how to use and rotate a KeySet.